### PR TITLE
Update Hentai2Read.lua

### DIFF
--- a/modules/lua/Hentai2Read.lua
+++ b/modules/lua/Hentai2Read.lua
@@ -54,7 +54,7 @@ end
 function GetPages()
 
     local imagesArray = tostring(dom):regex("'images'\\s*:\\s*(\\[.+?\\])", 1)
-    local cdnUrl = GetRoot(dom.SelectValue('//img[contains(@id,"arf-reader")]/@src'))..'hentai/'
+    local cdnUrl = dom.SelectValue('//img[contains(@id,"arf-reader")]/@src')
 
     for imageUrl in Json.New(imagesArray) do
         pages.Add(cdnUrl..tostring(imageUrl))


### PR DESCRIPTION
Extract the url directly from src.

This will return the iamges in `avif` format by default. The supported formats are `jpeg`, `webp`, `avif`, or `json`. It returns `avif` when the format parameter in the URL is set to `auto`. 