### PR TITLE
Update Hentai2Read.lua

### DIFF
--- a/modules/lua/Hentai2Read.lua
+++ b/modules/lua/Hentai2Read.lua
@@ -54,7 +54,7 @@ end
 function GetPages()
 
     local imagesArray = tostring(dom):regex("'images'\\s*:\\s*(\\[.+?\\])", 1)
-    local cdnUrl = GetRoot(dom.SelectValue('//img[contains(@id,"arf-reader")]/@src'))..'hentai/'
+    local cdnUrl = 'https://hentai2read.com/cdn-cgi/image/format=webp/https://static.hentaicdn.com/hentai'
 
     for imageUrl in Json.New(imagesArray) do
         pages.Add(cdnUrl..tostring(imageUrl))


### PR DESCRIPTION
Hardcode url for CDN. 

Not familiar with LUA, so I just hardcoded the CDN url that works for now..
This will return the images in `webp` format by default. The supported formats are `jpeg`, `webp`, `avif`, or `json`. It returns `avif` when the format parameter in the URL is set to auto, but I set it to `webp` since it is more supported.