### PR TITLE
Send headers with the correct case

### DIFF
--- a/modules/lua/9Hentai.lua
+++ b/modules/lua/9Hentai.lua
@@ -25,14 +25,14 @@ end
 local function GetGalleryJson()
 
     local apiEndpoint = GetApiEndpoint()
-    
-    http.Headers['content-type'] = 'application/json;charset=UTF-8'
-    http.Headers['origin'] = GetRoot(url)
-    http.Headers['x-csrf-token'] = dom.SelectValue('//meta[@name="csrf-token"]/@content')
-    http.Headers['x-requested-with'] = 'XMLHttpRequest'
+
+    http.Headers['Content-Type'] = 'application/json;charset=utf-8'
+    http.Headers['Origin'] = GetRoot(url)
+    http.Headers['X-CSRF-TOKEN'] = dom.SelectValue('//meta[@name="csrf-token"]/@content')
+    http.Headers['X-Requested-With'] = 'XMLHttpRequest'
 
     if(not isempty(http.Cookies.GetCookie('XSRF-TOKEN'))) then
-        http.Headers['x-xsrf-token'] = http.Cookies.GetCookie('XSRF-TOKEN')
+        http.Headers['X-XSRF-TOKEN'] = http.Cookies.GetCookie('XSRF-TOKEN')
     end
 
     local json = http.Post(apiEndpoint, '{"id":'..GetGalleryId()..'}')

--- a/modules/lua/AkumaMoe.lua
+++ b/modules/lua/AkumaMoe.lua
@@ -37,9 +37,9 @@ function GetPages()
     local galleryId = url:regex('\\/g\\/([^\\/?#]+)', 1)
     local csrfToken = dom.SelectValue('//meta[@name="csrf-token"]/@content')
 
-    http.Headers['accept'] = '*/*'
-    http.Headers['x-csrf-token'] = csrfToken
-    http.Headers['x-requested-with'] = 'XMLHttpRequest'
+    http.Headers['Accept'] = '*/*'
+    http.Headers['X-CSRF-TOKEN'] = csrfToken
+    http.Headers['X-Requested-With'] = 'XMLHttpRequest'
 
     local imagesJson = Json.New(http.Post('//akuma.moe/g/' .. galleryId))
     local imagesScript = dom.SelectValue('//script[contains(text(),"img_prt")]')

--- a/modules/lua/ComicK.lua
+++ b/modules/lua/ComicK.lua
@@ -30,9 +30,9 @@ end
 
 local function SetUpApiHeaders()
 
-    http.Headers['accept'] = '*/*'
-    http.Headers['origin'] = GetRoot(url):trim('/')
-    http.Headers['referer'] = GetRoot(url)
+    http.Headers['Accept'] = '*/*'
+    http.Headers['Origin'] = GetRoot(url):trim('/')
+    http.Headers['Referer'] = GetRoot(url)
 
 end
 

--- a/modules/lua/ComicNaver.lua
+++ b/modules/lua/ComicNaver.lua
@@ -16,10 +16,10 @@ end
 
 local function SetUpApiHeaders()
 
-    http.Headers['accept'] = 'application/json, text/plain, */*'
+    http.Headers['Accept'] = 'application/json, text/plain, */*'
 
     if(http.Cookies.Contains('XSRF-TOKEN')) then
-        http.Headers['X-Xsrf-Token'] = http.Cookies['XSRF-TOKEN']
+        http.Headers['X-XSRF-TOKEN'] = http.Cookies['XSRF-TOKEN']
     end
     
 end

--- a/modules/lua/CoolComics.lua
+++ b/modules/lua/CoolComics.lua
@@ -19,8 +19,8 @@ end
 
 local function GetApiJson(endpoint)
 
-    http.Headers['accept'] = 'application/json, text/javascript, */*; q=0.01'
-    http.Headers['x-requested-with'] = 'XMLHttpRequest'
+    http.Headers['Accept'] = 'application/json, text/javascript, */*; q=0.01'
+    http.Headers['X-Requested-With'] = 'XMLHttpRequest'
 
     return Json.New(http.Get(GetApiUrl() .. endpoint))
 

--- a/modules/lua/Coolmic.lua
+++ b/modules/lua/Coolmic.lua
@@ -47,8 +47,8 @@ end
 
 local function GetApiJson(id)
 
-    http.Headers['accept'] = 'application/json, text/plain, */*'
-    
+    http.Headers['Accept'] = 'application/json, text/plain, */*'
+
     return Json.New(http.Get(GetApiUrl() .. id))
 
 end


### PR DESCRIPTION
Send headers with the correct case (for the non-standard headers I have verified the correct case manually in Firefox since it allow to view raw headers).

Although usually it doesn't matter it is possible (even if unlikely) for the website to verify the case of headers (at least from PHP is possible) and reject the request in the future.

Note: I will do these changes in more than one PR since many site require manual verification.