### PR TITLE
New URL Path Scheme for Asura Scans + Radical Dom Change

### DIFF
--- a/modules/lua/AsuraScans.lua
+++ b/modules/lua/AsuraScans.lua
@@ -1,0 +1,81 @@
+function Register()
+
+    module.Name = 'Asura Scans'
+    module.Language = 'English'
+
+    module.Domains.Add('asura.gg')
+    module.Domains.Add('asura.nacm.xyz')
+    module.Domains.Add('asuracomic.net')
+    module.Domains.Add('asuracomics.com')
+    module.Domains.Add('asuracomics.gg')
+    module.Domains.Add('asurascans.com')
+    module.Domains.Add('asuratoon.com')
+    module.Domains.Add('www.asurascans.com')
+
+    if(API_VERSION >= 20230823) then
+        module.DeferHttpRequests = true
+    end
+
+end
+
+local function CleanMetadataFieldValue(value)
+
+    -- Empty metadata fields have the value " _ ", which should be blanked out.
+
+    if(tostring(value):trim() == '_') then
+        return ""
+    end
+
+    return value
+
+end
+
+local function RedirectToNewSerieUrl()
+
+    -- For some serie, the path looks like like this:
+    -- /series/serie-title-name-b075e10b
+    -- That numeric suffix unique id could change occassionally, breaking existing URLs in bookmarks or the download queue.
+    -- If we hit a 404 page for a serie URL, attempt to find the current alphanumeric ID and update the URL.
+    -- See https://github.com/HDoujinDownloader/HDoujinDownloader/issues/158
+
+end
+
+function GetInfo()
+
+    RedirectToNewSerieUrl()
+
+    info.Url = url
+    info.Title = dom.SelectValue('//span[contains(@class,"text-xl")]')
+    info.Description = dom.SelectValue('//h3[contains(text(),"Synopsis")]/following-sibling::span')
+    info.Publisher = CleanMetadataFieldValue(dom.SelectValue('//h3[contains(text(),"Serialization")]/following-sibling::h3'))
+    info.Author = CleanMetadataFieldValue(dom.SelectValue('//h3[contains(text(),"Author")]/following-sibling::h3'))
+    info.Artist = CleanMetadataFieldValue(dom.SelectValue('//h3[contains(text(),"Artist")]/following-sibling::h3'))
+    info.Tags = dom.SelectValues('//h3[contains(text(),"Genres")]/following-sibling::div/button')
+    info.Status = dom.SelectValue('//h3[contains(text(),"Status")]/following-sibling::h3')
+    info.Type = dom.SelectValue('//h3[contains(text(),"Type")]/following-sibling::h3')
+    info.Scanlator = 'Asura Scans'
+
+end
+
+function GetChapters()
+
+    RedirectToNewSerieUrl()
+
+    for chapterNode in dom.SelectElements('//div/a[contains(@class,"block") and contains(@href, "chapter")]') do
+
+        local chapterUrl = chapterNode.SelectValue('@href')
+        local chapterTitle = chapterNode.SelectValue('div/h3[1]')
+
+        chapters.Add(chapterUrl, chapterTitle)
+
+    end
+
+    chapters.Reverse()
+
+end
+
+function GetPages()
+
+    pages.AddRange(dom.SelectValues('//img[contains(@src, "comics")]/@src'))
+
+end

--- a/modules/lua/AsuraScans.lua
+++ b/modules/lua/AsuraScans.lua
@@ -61,10 +61,10 @@ function GetChapters()
 
     RedirectToNewSerieUrl()
 
-    for chapterNode in dom.SelectElements('//div/a[contains(@class,"block") and contains(@href, "chapter")]') do
+    for chapterNode in dom.SelectElements('//div//a[contains(@class,"block") and contains(@href, "chapter")]') do
 
         local chapterUrl = chapterNode.SelectValue('@href')
-        local chapterTitle = chapterNode.SelectValue('div/h3[1]')
+        local chapterTitle = chapterNode.SelectValue('.')
 
         chapters.Add(chapterUrl, chapterTitle)
 

--- a/modules/lua/WpMangaStream.lua
+++ b/modules/lua/WpMangaStream.lua
@@ -6,13 +6,6 @@ function Register()
     module.Name = 'MangaStream'
     module.Language = 'English'
 
-    module.Domains.Add('asura.gg', 'Asura Scans')
-    module.Domains.Add('asura.nacm.xyz', 'Asura Scans')
-    module.Domains.Add('asuracomic.net', 'Asura Scans')
-    module.Domains.Add('asuracomics.com', 'Asura Scans')
-    module.Domains.Add('asuracomics.gg', 'Asura Scans')
-    module.Domains.Add('asurascans.com', 'Asura Scans')
-    module.Domains.Add('asuratoon.com', 'Asura Scans')
     module.Domains.Add('cosmicscans.com', 'Cosmic Scans')
     module.Domains.Add('cosmic-scans.com', 'Cosmic Scans')
     module.Domains.Add('luminous-scans.com', 'Luminous Scans')
@@ -22,7 +15,6 @@ function Register()
     module.Domains.Add('luminousscans.net', 'Luminous Scans')
     module.Domains.Add('lumitoon.com', 'Luminous Scans')
     module.Domains.Add('manhwafreak.site', 'Manhwa Freak')
-    module.Domains.Add('www.asurascans.com', 'Asura Scans')
 
     if(API_VERSION >= 20230823) then
         module.DeferHttpRequests = true


### PR DESCRIPTION
Although it seems that Asura still uses MangaStream as its visual theme, the site's source code has evolved in a very distinct way from the basic template.  So I decided to add a separate module. This is also in order to find a solution that can adapt more easily to the constantly changing URL schema that allows us to access the resource. 

_I've left this function empty for now :_ 

```
local function RedirectToNewSerieUrl()

    -- For some serie, the path looks like like this:
    -- /series/serie-title-name-b075e10b
    -- That numeric suffix unique id could change occassionally, breaking existing URLs in bookmarks or the download queue.
    -- If we hit a 404 page for a serie URL, attempt to find the current alphanumeric ID and update the URL.
    -- See https://github.com/HDoujinDownloader/HDoujinDownloader/issues/158

end
```

Although if my solution (for more #158 ) is validated, it will only be used in specific cases, where a search will have to be carried out directly on the site because of the more complex URL changes. Otherwise, search will be made using the bookmark data (especially title). 