### PR TITLE
mangapark.net: Fix image list

### DIFF
--- a/modules/lua/MangaParkV5.lua
+++ b/modules/lua/MangaParkV5.lua
@@ -73,7 +73,7 @@ function GetPages()
 
         -- Ignore thumbnail images.
 
-        if(imageUrl:contains('/comic/') or imageUrl:contains('/image/mpup/')) then
+        if(imageUrl:contains('/comic/') or imageUrl:contains('/image/mpup/') or imageUrl:contains('/media/mpup/')) then
             pages.Add(imageUrl)
         end
 


### PR DESCRIPTION
Images filters seem doesn't work for this chapter  => https://mangapark.net/title/10749-en-one-punch-man/9003278-chapter-205