### PR TITLE
asuracomic.net: Fix image URLs

### DIFF
--- a/modules/lua/AsuraScans.lua
+++ b/modules/lua/AsuraScans.lua
@@ -106,7 +106,7 @@ function GetPages()
 
     if(isempty(pages)) then
 
-        local nextDataScript = dom.SelectValue('//script[contains(text(),"published_at")]')
+        local nextDataScript = dom.SelectValue('//script[contains(text(),"published_at")][last()]')
 
         pages.AddRange(nextDataScript:regexmany('"url\\\\":\\\\"([^"]+)\\\\"', 1))
 


### PR DESCRIPTION
It doesn't seem to retrieve all or any pages for some chapters like https://asuracomic.net/series/swordmasters-youngest-son-7c373777/chapter/139