### PR TITLE
Mangaworld changed it's domain.

### DIFF
--- a/modules/lua/MangaWorld.lua
+++ b/modules/lua/MangaWorld.lua
@@ -9,6 +9,7 @@ function Register()
     module.Domains.Add('www.mangaworld.ac')
     module.Domains.Add('www.mangaworld.in')
     module.Domains.Add('www.mangaworld.nz')
+    module.Domains.Add('www.mangaworld.cx')
 
     module.Settings.AddCheck('Download by volume', false)
         .WithToolTip('If enabled, manga will be downloaded by volume instead of by chapter.')


### PR DESCRIPTION
Hi. It seems like Mangaword changet its domain name. I added another entry in the lua module adding the new domanin name.

This should make the module work again to download again from MangaWorld site. now that the domain has changed it does not work obviously.